### PR TITLE
Adding GPG Key to Workflow

### DIFF
--- a/.github/workflows/update-stage.yml
+++ b/.github/workflows/update-stage.yml
@@ -10,8 +10,16 @@ jobs:
     env:
       SOURCE_BRANCH: main
       TARGET_BRANCH: stage
+      GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
 
     steps:
+      - name: Read GPG Key
+        run: |
+          echo -n "${{ secrets.GPG_SIGNING_KEY }}" | base64 --decode | gpg --import
+      - name: Set up GPG for commit signing
+        run: |
+          git config --global user.signingkey $GPG_KEY_ID
+          git config --global commit.gpgsign true
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
As of right now this workflow doesn't sign its commit's which is causing it to violate repo rules: https://github.com/innovateorange/DiscordBot/rules\?ref\=refs%2Fheads%2Fstage so the hope is that adding GPG Keys will fix this issue.

## What does this this PR do?

<!--- 
Briefly describe the purpose of this PR.
- What feature, bug fix, or change does it introduce?
- Why is this change necessary?
-->

## Testing & Validation
<!--
Describe how you tested / validated these changes
- Describe your validation steps 
- Add and neccessary screenshots here for your reviewer
-->

## Related issues

<!--
Link any related issues or discussions.
Example: Closes #123
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the stage deployment workflow to import a GPG key from secrets and enable Git commit signing for automated updates. Steps run before repository checkout to ensure all CI-generated commits are signed, improving authenticity and integrity of changes. No impact to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->